### PR TITLE
对于配置文件的配置读取，新增环境变量语法的兼容。

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ if you have a yaml config
 some:
   config: 1
 ttl: 30s
+service:
+  name: ${NAME||go-archaius}
 ```
 after adding file
 ```go
@@ -93,7 +95,11 @@ you can get value
 ```go
 ttl := archaius.GetString("ttl", "60s")
 i := archaius.GetInt("some.config", "")
+serviceName := archaius.GetString("service.name", "")
 ```
+note:
+
+For `service.name` config with value of  `${NAME||go-archaius}` is support env syntax. If environment variable `${NAME}` isn't setting, return default value `go-archaius`. It's setted, will get real environment variable value.
 
 if you want to read some.config from env
 you can run

--- a/scripts/travis/formatChecker.sh
+++ b/scripts/travis/formatChecker.sh
@@ -1,4 +1,4 @@
-diff -u <(echo -n) <(find . -name "*.go" -not -path ".git/*" -not -path "./third_party/*" | xargs gofmt -s -d)
+diff -u <(echo -n) <(find . -name "*.go" -not -path ".git/*" -not -path "./third_party/*" | xargs go fmt -s -d)
 if [ $? == 0 ]; then
 	echo "Code is formatted properly"
 	exit 0

--- a/scripts/travis/goLintChecker.sh
+++ b/scripts/travis/goLintChecker.sh
@@ -1,4 +1,4 @@
-diff -u <(echo -n) <(golint ./... | grep -v stutters | grep -v _test | grep -v examples)
+diff -u <(echo -n) <(go lint ./... | grep -v stutters | grep -v _test | grep -v examples)
 if [ $? == 0 ]; then
 	echo "No GoLint warnings found"
 	exit 0

--- a/source/util/expand.go
+++ b/source/util/expand.go
@@ -11,11 +11,11 @@ func ExpandValueEnv(value string) (realValue string) {
 	vLen := len(value)
 	// 3 = ${}
 	if vLen < 3 {
-		return realValue
+		return
 	}
 	// Need start with "${" and end with "}", then return.
 	if value[0] != '$' || value[1] != '{' || value[vLen-1] != '}' {
-		return realValue
+		return
 	}
 
 	key := ""
@@ -37,6 +37,6 @@ func ExpandValueEnv(value string) (realValue string) {
 		realValue = defaultV
 	}
 
-	return realValue
+	return
 }
 

--- a/source/util/expand.go
+++ b/source/util/expand.go
@@ -11,11 +11,11 @@ func ExpandValueEnv(value string) (realValue string) {
 	vLen := len(value)
 	// 3 = ${}
 	if vLen < 3 {
-		return
+		return realValue
 	}
 	// Need start with "${" and end with "}", then return.
 	if value[0] != '$' || value[1] != '{' || value[vLen-1] != '}' {
-		return
+		return realValue
 	}
 
 	key := ""
@@ -37,6 +37,6 @@ func ExpandValueEnv(value string) (realValue string) {
 		realValue = defaultV
 	}
 
-	return
+	return realValue
 }
 

--- a/source/util/expand.go
+++ b/source/util/expand.go
@@ -1,0 +1,42 @@
+package util
+
+import "os"
+
+// if string like ${NAME||archaius}
+// will query environment variable for ${NAME}
+// if environment variable is "" return default string `archaius`
+func ExpandValueEnv(value string) (realValue string) {
+	realValue = value
+
+	vLen := len(value)
+	// 3 = ${}
+	if vLen < 3 {
+		return
+	}
+	// Need start with "${" and end with "}", then return.
+	if value[0] != '$' || value[1] != '{' || value[vLen-1] != '}' {
+		return
+	}
+
+	key := ""
+	defaultV := ""
+	// value start with "${"
+	for i := 2; i < vLen; i++ {
+		if value[i] == '|' && (i+1 < vLen && value[i+1] == '|') {
+			key = value[2:i]
+			defaultV = value[i+2 : vLen-1] // other string is default value.
+			break
+		} else if value[i] == '}' {
+			key = value[2:i]
+			break
+		}
+	}
+
+	realValue = os.Getenv(key)
+	if realValue == "" {
+		realValue = defaultV
+	}
+
+	return
+}
+

--- a/source/util/expand_test.go
+++ b/source/util/expand_test.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"os"
+	"testing"
+)
+
+func TestExpandValueEnv(t *testing.T) {
+	str := "${NAME||archaius}"
+	if e := os.Setenv("NAM", "go-archaius"); e != nil {
+		t.Logf("err:%+v", e)
+	}
+	realStr := ExpandValueEnv(str)
+	t.Logf("realStr: %s", realStr)
+}

--- a/source/util/file_handler.go
+++ b/source/util/file_handler.go
@@ -50,7 +50,12 @@ func retrieveItems(prefix string, subItems yaml.MapSlice) map[string]interface{}
 				))
 				continue
 			}
-			result[prefix+k] = item.Value
+
+			var keyVal = item.Value
+			if val, ok := item.Value.(string); ok {
+				keyVal = ExpandValueEnv(val)
+			}
+			result[prefix+k] = keyVal
 		}
 	}
 


### PR DESCRIPTION
issus地址：https://github.com/go-chassis/go-archaius/issues/108

例如下面的例子，使用如果配置文件中的value有${GO||/usr/local/go}这种格式的字符串，
就去获取一下环境变量${GO}的值，如果环境变量为空，就返回||与)之间的默认字符串。