### PR TITLE
critical bug: dead lock

### DIFF
--- a/examples/event/event.yaml
+++ b/examples/event/event.yaml
@@ -1,8 +1,1 @@
-name: Tom Smith
-age: 1
-#spouse
-#   name: Jane Smith
-#   age: 23
-children:
-   name: Jimmy Smith
-   age: 19
+age: 3321111

--- a/source/cli/cli.go
+++ b/source/cli/cli.go
@@ -84,8 +84,8 @@ func (cli *Source) GetConfigurations() (map[string]interface{}, error) {
 
 //GetConfigurationByKey gets required configuration for matching key
 func (cli *Source) GetConfigurationByKey(key string) (interface{}, error) {
-	cli.Lock()
-	defer cli.Unlock()
+	cli.RLock()
+	defer cli.RUnlock()
 	value, ok := cli.Configurations[key]
 	if !ok {
 		return nil, source.ErrKeyNotExist

--- a/source/configmap/configmap_source.go
+++ b/source/configmap/configmap_source.go
@@ -276,8 +276,8 @@ func (cmSource *configMapSource) GetConfigurations() (map[string]interface{}, er
 }
 
 func (cmSource *configMapSource) GetConfigurationByKey(key string) (interface{}, error) {
-	cmSource.Lock()
-	defer cmSource.Unlock()
+	cmSource.RLock()
+	defer cmSource.RUnlock()
 
 	for ckey, confInfo := range cmSource.Configurations {
 		if confInfo == nil {

--- a/source/env/env.go
+++ b/source/env/env.go
@@ -83,8 +83,8 @@ func (es *Source) GetConfigurations() (map[string]interface{}, error) {
 
 //GetConfigurationByKey gets required configuration for a particular key
 func (es *Source) GetConfigurationByKey(key string) (interface{}, error) {
-	es.Lock()
-	defer es.Unlock()
+	es.RLock()
+	defer es.RUnlock()
 	value, ok := es.Configurations[key]
 	if !ok {
 		return nil, source.ErrKeyNotExist

--- a/source/file/file.go
+++ b/source/file/file.go
@@ -290,8 +290,8 @@ func (fSource *Source) GetConfigurations() (map[string]interface{}, error) {
 
 //GetConfigurationByKey get one key value
 func (fSource *Source) GetConfigurationByKey(key string) (interface{}, error) {
-	fSource.Lock()
-	defer fSource.Unlock()
+	fSource.RLock()
+	defer fSource.RUnlock()
 
 	for ckey, confInfo := range fSource.Configurations {
 		if confInfo == nil {
@@ -433,6 +433,7 @@ func (wth *watch) watchFile() {
 				openlog.Error("convert error " + err.Error())
 				continue
 			}
+			openlog.Debug(fmt.Sprintf("new config: %v", newConf))
 			events := wth.fileSource.compareUpdate(newConf, event.Name)
 			openlog.Debug(fmt.Sprintf("generated events %v", events))
 			for _, e := range events {

--- a/source/mem/mem.go
+++ b/source/mem/mem.go
@@ -66,8 +66,8 @@ func (ms *Source) GetConfigurations() (map[string]interface{}, error) {
 
 //GetConfigurationByKey gets required memory configuration for a particular key
 func (ms *Source) GetConfigurationByKey(key string) (interface{}, error) {
-	ms.Lock()
-	defer ms.Unlock()
+	ms.RLock()
+	defer ms.RUnlock()
 	value, ok := ms.Configurations[key]
 	if !ok {
 		return nil, source.ErrKeyNotExist

--- a/source/remote/configcenter/config_center_source.go
+++ b/source/remote/configcenter/config_center_source.go
@@ -149,9 +149,9 @@ func (rs *Source) refreshConfigurations() error {
 
 //GetConfigurationByKey gets required configuration for a particular key
 func (rs *Source) GetConfigurationByKey(key string) (interface{}, error) {
-	rs.Lock()
+	rs.RLock()
 	configSrcVal, ok := rs.currentConfig[key]
-	rs.Unlock()
+	rs.RUnlock()
 	if ok {
 		return configSrcVal, nil
 	}


### PR DESCRIPTION
比如2个协程分别抢占了file的锁和mem的锁，并都期望读取彼此的锁，即死锁。
再比如2个协程都要读archius配置，并且业务代码里有另一个写锁，2个协程分别占用了业务锁和archaius内的锁，即死锁
老代码在读map场景用写锁本来就是错误的