### PR TITLE
delete event fo moudule events would be ignored

### DIFF
--- a/event/event_system.go
+++ b/event/event_system.go
@@ -123,6 +123,7 @@ type Event struct {
 	EventType   string
 	Key         string
 	Value       interface{}
+	HasUpdated  bool
 }
 
 // Listener All Listener should implement this Interface

--- a/source/manager.go
+++ b/source/manager.go
@@ -405,7 +405,7 @@ func (m *Manager) updateEvent(e *event.Event) error {
 		return errors.New("nil or invalid event supplied")
 	}
 	if e.HasUpdated {
-		openlog.Info(fmt.Sprintf("config update event %s has been updated", *e))
+		openlog.Info(fmt.Sprintf("config update event %+v has been updated", *e))
 		return nil
 	}
 	openlog.Info("config update event received")

--- a/source/manager.go
+++ b/source/manager.go
@@ -404,6 +404,10 @@ func (m *Manager) updateEvent(e *event.Event) error {
 	if e == nil || e.EventSource == "" || e.Key == "" {
 		return errors.New("nil or invalid event supplied")
 	}
+	if e.HasUpdated {
+		openlog.Info(fmt.Sprintf("config update event %s has been updated", *e))
+		return nil
+	}
 	openlog.Info("config update event received")
 	switch e.EventType {
 	case event.Create, event.Update:
@@ -444,6 +448,7 @@ func (m *Manager) updateEvent(e *event.Event) error {
 
 	}
 
+	e.HasUpdated = true
 	return nil
 }
 


### PR DESCRIPTION
问题：当触发配置删除事件时，模块事件通知处理过程中，删除事件会由于该事件已经更新到archaius的缓存从而导致重复更新失败，最终导致该删除事件被忽略。
------------------------------------------
解决：给事件增加一个标记，标记该事件是否已经被manager更新到缓存里，如果已更新，则直接返回成功，不重复处理