### PR TITLE
Fix bug when expand env value for yaml array

### DIFF
--- a/examples/file/f1.yaml
+++ b/examples/file/f1.yaml
@@ -1,1 +1,5 @@
 age: 131
+name: ${NAME||peter}
+favorite:
+  - ${FRUIT||apple}
+  - ${COLOR||red}

--- a/examples/file/main.go
+++ b/examples/file/main.go
@@ -15,6 +15,7 @@ func main() {
 	}
 	log.Println(archaius.Get("age"))
 	log.Println(archaius.Get("name"))
+	log.Println(archaius.Get("favorite"))
 	log.Println(archaius.Get("c"))
 	log.Println(archaius.Get("b"))
 	err = archaius.AddFile("f2.yaml")

--- a/source/util/file_handler.go
+++ b/source/util/file_handler.go
@@ -61,9 +61,11 @@ func retrieveItems(prefix string, subItems yaml.MapSlice) map[string]interface{}
 				))
 				continue
 			}
-			var keyVal = item.Value
-			if val, ok := item.Value.(string); ok {
-				keyVal = ExpandValueEnv(val)
+			keyVal := item.Value.([]interface{})
+			for i, subVal := range keyVal {
+				if subStr, ok := subVal.(string); ok {
+					keyVal[i] = ExpandValueEnv(subStr)
+				}
 			}
 			result[prefix+k] = keyVal
 			// replace  prefix+k with new arr value


### PR DESCRIPTION
When the env value like "${PORT||8080}" appears as an element of a yaml array, it does not expand and is treated as a plain text "${PORT||8080}"