### PR TITLE
Env expansion for file handler supports upper and lower case in bash4 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ serviceAddr := archaius.GetString("service.addr", "")
 ```
 note:
 
-1. For `service.name` config with value of  `${NAME||go-archaius}` is support env syntax. If environment variable `${NAME}` isn't setting, return default value `go-archaius`. It's setted, will get real environment variable value.
+1. For `service.name` config with value of  `${NAME||go-archaius}` is support env syntax. If environment variable `${NAME}` isn't setting, return default value `go-archaius`. It's setted, will get real environment variable value. Besides, if `${Name^^}` is used instead of `${Name}`, the value of environment variable `Name` will be shown in upper case, and `${Name,,}` will bring the value in lower case.
 2. For `service.addr` config is support "expand syntax". If environment variable `${IP}` or `${PORT}` is setted, will get env config. 
 eg: `export IP=0.0.0.0 PORT=443` , `archaius.GetString("service.addr", "")` will return `0.0.0.0:443` .
 

--- a/source/util/expand.go
+++ b/source/util/expand.go
@@ -8,7 +8,7 @@ import (
 
 // The name of a variable can contain only letters (a to z or A to Z), numbers ( 0 to 9) or
 // the underscore character ( _), and can't begin with number.
-const envVariable = `\${([a-zA-Z_]{1}[\w]+)[\|]{2}(.*?)}`
+const envVariable = `\${([a-zA-Z_]{1}[\w]+)((?:\,\,|\^\^)?)[\|]{2}(.*?)}`
 
 // reg exp
 var variableReg *regexp.Regexp
@@ -35,7 +35,13 @@ func ExpandValueEnv(value string) (realValue string) {
 	for _, sub := range submatch {
 		item := os.Getenv(sub[1])
 		if item == "" {
-			item = sub[2]
+			item = sub[3]
+		} else {
+			if sub[2] == "^^" {
+				item = strings.ToUpper(item)
+			} else if sub[2] == ",," {
+				item = strings.ToLower(item)
+			}
 		}
 		realValue = strings.ReplaceAll(realValue, sub[0], item)
 	}

--- a/source/util/expand.go
+++ b/source/util/expand.go
@@ -33,6 +33,9 @@ func ExpandValueEnv(value string) (realValue string) {
 
 	realValue = value
 	for _, sub := range submatch {
+		if len(sub) != 4 { //rule matching behaves in an unexpected way
+			continue
+		}
 		item := os.Getenv(sub[1])
 		if item == "" {
 			item = sub[3]

--- a/source/util/expand_test.go
+++ b/source/util/expand_test.go
@@ -49,4 +49,13 @@ func TestExpandValueEnv(t *testing.T) {
 		t.Logf("err:%+v", e)
 	}
 	assert.Equal(t, "${IP|}", ExpandValueEnv(str10))
+
+	os.Unsetenv("UPPER_ENV")
+	str11 := "env:${UPPER_ENV^^||local}"
+	assert.Equal(t, "env:local", ExpandValueEnv(str11))
+	os.Setenv("UPPER_ENV", "Test")
+	assert.Equal(t, "env:TEST", ExpandValueEnv(str11))
+	str12 := "env:${UPPER_ENV,,||local}"
+	assert.Equal(t, "env:test", ExpandValueEnv(str12))
+	os.Unsetenv("UPPER_ENV")
 }


### PR DESCRIPTION
Use ${POD_IP,,||local} to get environment variable POD_IP in lower case and Use ${POD_IP^^||local} to get the same variable in upper case