### PR TITLE
fixed bug：Fix the problem that some types of yaml configuration cannot be converted, resulting in configuration loss

### DIFF
--- a/source/unmarshal.go
+++ b/source/unmarshal.go
@@ -327,18 +327,15 @@ func (m *Manager) populateMap(prefix string, mapType reflect.Type, rValues refle
 
 			// maybe next map type
 			if mapValueType != setVal.Type() {
-				return rValue, nil
-
+				returnCongValue, err := m.toRvalueType(setVal.Interface(), reflect.New(mapValueType).Elem())
+				if err != nil {
+					return rValue, fmt.Errorf(fmtValueNotMatched,
+						prefix+key, mapValueType, setVal.String())
+				}
+				setVal = returnCongValue
 			}
-
-			returnCongValue, err := m.toRvalueType(setVal.Interface(), reflect.New(mapValueType).Elem())
-			if err != nil {
-				return rValue, fmt.Errorf(fmtValueNotMatched,
-					prefix+key, mapValueType, setVal.String())
-			}
-
 			if rValue.CanSet() {
-				rValue.SetMapIndex(reflect.ValueOf(key[1:]), returnCongValue)
+				rValue.SetMapIndex(reflect.ValueOf(key[1:]), setVal)
 			}
 		default:
 			splitKey := strings.Split(key, `.`)


### PR DESCRIPTION
修复yaml配置部分类型无法转换导致配置丢失的问题
比如 yaml配置value为bool类型 而接受类型为stirng 此时会将 bool转成stirng
https://github.com/go-chassis/go-archaius/issues/122
https://github.com/go-chassis/go-chassis/issues/991