### PR TITLE
fix panic when update with slice / map val

### DIFF
--- a/archaius_test.go
+++ b/archaius_test.go
@@ -115,17 +115,22 @@ func TestConfig_RegisterListener(t *testing.T) {
 }
 
 func TestConfig_Update(t *testing.T) {
-	assert.NoError(t, archaius.Set("aNumber", 1))
-	assert.NoError(t, archaius.Set("aNumber", 2))
-
-	assert.NoError(t, archaius.Set("aSlice", []int{1,2,3}))
-	// nothing changed
-	assert.NoError(t, archaius.Set("aSlice", []int{1,2,3}))
-
-	assert.NoError(t, archaius.Set("aMap", map[int]int{1:1}))
-	assert.NoError(t, archaius.Set("aMap", map[int]int{1:1}))
-	assert.NoError(t, archaius.Set("aMap", 1))
-	assert.NoError(t, archaius.Set("aMap", map[int]int{1:1}))
+	t.Run("update a simple type config", func(t *testing.T) {
+		assert.NoError(t, archaius.Set("aNumber", 1))
+		assert.NoError(t, archaius.Set("aNumber", 2))
+	})
+	t.Run("update a slice config", func(t *testing.T) {
+		assert.NoError(t, archaius.Set("aSlice", []int{1,2,3}))
+		assert.NoError(t, archaius.Set("aSlice", []int{1,2,3}))
+		assert.NoError(t, archaius.Set("aSlice", 1))
+		assert.NoError(t, archaius.Set("aSlice", []int{1,2,3}))
+	})
+	t.Run("update a map config", func(t *testing.T) {
+		assert.NoError(t, archaius.Set("aMap", map[int]int{1: 1}))
+		assert.NoError(t, archaius.Set("aMap", map[int]int{1: 1}))
+		assert.NoError(t, archaius.Set("aMap", 1))
+		assert.NoError(t, archaius.Set("aMap", map[int]int{1: 1}))
+	})
 }
 
 func TestUnmarshalConfig(t *testing.T) {

--- a/archaius_test.go
+++ b/archaius_test.go
@@ -19,8 +19,6 @@ func (e EListener) Event(event *event.Event) {
 	openlog.Info(fmt.Sprintf("config value after change %s |%s", event.Key, event.Value))
 }
 
-var filename2 string
-
 func TestInit(t *testing.T) {
 	f1Bytes := []byte(`
 age: 14
@@ -33,7 +31,7 @@ exist: true
 `)
 	d, _ := os.Getwd()
 	filename1 := filepath.Join(d, "f1.yaml")
-	filename2 = filepath.Join(d, "f2.yaml")
+	filename2 := filepath.Join(d, "f2.yaml")
 	f1, err := os.Create(filename1)
 	assert.NoError(t, err)
 	defer f1.Close()
@@ -114,6 +112,20 @@ func TestConfig_RegisterListener(t *testing.T) {
 	assert.NoError(t, err)
 	defer archaius.UnRegisterListener(eventHandler, "a*")
 
+}
+
+func TestConfig_Update(t *testing.T) {
+	assert.NoError(t, archaius.Set("aNumber", 1))
+	assert.NoError(t, archaius.Set("aNumber", 2))
+
+	assert.NoError(t, archaius.Set("aSlice", []int{1,2,3}))
+	// nothing changed
+	assert.NoError(t, archaius.Set("aSlice", []int{1,2,3}))
+
+	assert.NoError(t, archaius.Set("aMap", map[int]int{1:1}))
+	assert.NoError(t, archaius.Set("aMap", map[int]int{1:1}))
+	assert.NoError(t, archaius.Set("aMap", 1))
+	assert.NoError(t, archaius.Set("aMap", map[int]int{1:1}))
 }
 
 func TestUnmarshalConfig(t *testing.T) {

--- a/source/manager.go
+++ b/source/manager.go
@@ -395,8 +395,8 @@ func (m *Manager) updateEventWithConfigUpdateLock(e *event.Event) error {
 		}
 		// we need to update cache if oldSrc != src || oldVal != val
 		m.updateCacheWithoutConfigUpdateLock(src.GetSourceName(), e.Key, val)
-		if oldVal == val {
-			openlog.Info(fmt.Sprintf("the key %s value %s is up-to-date, ignore value change", e.Key, val))
+		if reflect.DeepEqual(oldVal, val) {
+			openlog.Info(fmt.Sprintf("the key %q value %+v is up-to-date, ignore value change", e.Key, val))
 			return ErrIgnoreChange
 		}
 	}


### PR DESCRIPTION
修复一个 panic 错误，在 https://github.com/go-chassis/go-archaius/pull/151 中引入。
对应测试用例 TestConfig_Update，当配置值为 slice 或 map 时，发生 panic.