### PR TITLE
support first character to upper or lower

### DIFF
--- a/source/util/expand.go
+++ b/source/util/expand.go
@@ -4,11 +4,12 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"unicode"
 )
 
 // The name of a variable can contain only letters (a to z or A to Z), numbers ( 0 to 9) or
 // the underscore character ( _), and can't begin with number.
-const envVariable = `\${([a-zA-Z_]{1}[\w]+)((?:\,\,|\^\^)?)[\|]{2}(.*?)}`
+const envVariable = `\${([a-zA-Z_]{1}[\w]+)((?:\,\,|\^\^|\,|\^)?)[\|]{2}(.*?)}`
 
 // reg exp
 var variableReg *regexp.Regexp
@@ -44,6 +45,10 @@ func ExpandValueEnv(value string) (realValue string) {
 				item = strings.ToUpper(item)
 			} else if sub[2] == ",," {
 				item = strings.ToLower(item)
+			} else if sub[2] == "^" {
+				item = makeFirstUpperCase(item)
+			} else if sub[2] == "," {
+				item = makeFirstLowerCase(item)
 			}
 		}
 		realValue = strings.ReplaceAll(realValue, sub[0], item)
@@ -51,3 +56,22 @@ func ExpandValueEnv(value string) (realValue string) {
 
 	return
 }
+
+func makeFirstLowerCase(s string) string {
+	if len(s)==0 {
+		return s
+	}
+	r := []rune(s)
+	r[0] = unicode.ToLower(r[0])
+	return string(r)
+}
+
+func makeFirstUpperCase(s string) string {
+	if len(s)==0 {
+		return s
+	}
+	r := []rune(s)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
+}
+

--- a/source/util/expand.go
+++ b/source/util/expand.go
@@ -21,10 +21,21 @@ func init() {
 // if string like ${NAME||archaius}
 // will query environment variable for ${NAME}
 // if environment variable is "" return default string `archaius`
-// support multi variable, eg:
+// support multi variable, e.g.:
 //    value string => addr:${IP||127.0.0.1}:${PORT||8080}
 //    if environment variable =>  IP=0.0.0.0 PORT=443 , result => addr:0.0.0.0:443
 //    if no exist environment variable                , result => addr:127.0.0.1:8080
+// support toupper / tolower like bash,
+//    1. ^^: whole string to upper
+//    2.  ^: capital to upper
+//    3. ,,: whole string to lower
+//    4.  ,: capital to lower
+//    e.g.:
+//       os.Setenv("env", "TesT")
+//       ExpandValueEnv("${env^^||local}")  return "TEST"
+//       ExpandValueEnv("${env,,||local}")  return "test"
+//       ExpandValueEnv("${env^||local}")   return "TesT"
+//       ExpandValueEnv("${env,||local}")   return "tesT"
 func ExpandValueEnv(value string) (realValue string) {
 	value = strings.TrimSpace(value)
 	submatch := variableReg.FindAllStringSubmatch(value, -1)

--- a/source/util/expand_test.go
+++ b/source/util/expand_test.go
@@ -50,12 +50,27 @@ func TestExpandValueEnv(t *testing.T) {
 	}
 	assert.Equal(t, "${IP|}", ExpandValueEnv(str10))
 
-	os.Unsetenv("UPPER_ENV")
-	str11 := "env:${UPPER_ENV^^||local}"
+	os.Unsetenv("STR_ENV")
+	str11 := "env:${STR_ENV^^||local}"
+	str12 := "env:${STR_ENV,,||local}"
+	str13 := "env:${STR_ENV^||local}"
+	str14 := "env:${STR_ENV,||local}"
 	assert.Equal(t, "env:local", ExpandValueEnv(str11))
-	os.Setenv("UPPER_ENV", "Test")
+	assert.Equal(t, "env:local", ExpandValueEnv(str12))
+	assert.Equal(t, "env:local", ExpandValueEnv(str13))
+	assert.Equal(t, "env:local", ExpandValueEnv(str14))
+
+	os.Setenv("STR_ENV", "TesT")
 	assert.Equal(t, "env:TEST", ExpandValueEnv(str11))
-	str12 := "env:${UPPER_ENV,,||local}"
 	assert.Equal(t, "env:test", ExpandValueEnv(str12))
-	os.Unsetenv("UPPER_ENV")
+	assert.Equal(t, "env:TesT", ExpandValueEnv(str13))
+	assert.Equal(t, "env:tesT", ExpandValueEnv(str14))
+
+	os.Setenv("STR_ENV", "工Test")
+	assert.Equal(t, "env:工TEST", ExpandValueEnv(str11))
+	assert.Equal(t, "env:工test", ExpandValueEnv(str12))
+	assert.Equal(t, "env:工Test", ExpandValueEnv(str13))
+	assert.Equal(t, "env:工Test", ExpandValueEnv(str14))
+
+	os.Unsetenv("STR_ENV")
 }


### PR DESCRIPTION
读取环境变量值时，支持类似 shell 的 
${env^} 首字母转大写,  
${env,} 首字母转小写语法