### PR TITLE
支持将projectID传入kie server

### DIFF
--- a/options.go
+++ b/options.go
@@ -32,6 +32,7 @@ type RemoteInfo struct {
 	AutoDiscovery bool
 	APIVersion    string
 	RefreshPort   string
+	ProjectID     string
 }
 
 //Options hold options

--- a/source/remote/kie/kie_source.go
+++ b/source/remote/kie/kie_source.go
@@ -63,6 +63,7 @@ func NewKieSource(ci *archaius.RemoteInfo) (source.ConfigSource, error) {
 		AutoDiscovery: ci.AutoDiscovery,
 		Labels:        ci.DefaultDimension,
 		WatchTimeOut:  ci.RefreshInterval,
+		ProjectID:     ci.ProjectID,
 	}
 	k, err := NewKie(opts)
 	if err != nil {


### PR DESCRIPTION
目前无法支持Kie server 对应的project配置，只能读取默认的default下的配置