### PR TITLE
fix: confInfo set higher priority filepath

### DIFF
--- a/source/configmap/configmap_source.go
+++ b/source/configmap/configmap_source.go
@@ -512,6 +512,7 @@ func (cmSource *configMapSource) compareUpdate(newconf map[string]interface{}, f
 
 				} else if filePathPriority < priority { // lower the vale higher is the priority
 					confInfo.Value = newConfValue
+					confInfo.FilePath = filePath
 					fileConfs[key] = confInfo
 					events = append(events, &event.Event{EventSource: ConfigMapConfigSourceConst,
 						Key: key, EventType: event.Update, Value: newConfValue})

--- a/source/configmap/configmap_source_test.go
+++ b/source/configmap/configmap_source_test.go
@@ -125,9 +125,9 @@ func TestDynamicConfigurations(t *testing.T) {
 	check(err)
 
 	cmSource := NewConfigMapSource()
+	cmSource.AddFile(filename3, 2, nil)
 	cmSource.AddFile(filename1, 0, nil)
 	cmSource.AddFile(filename2, 1, nil)
-	cmSource.AddFile(filename3, 2, nil)
 
 	dynHandler := new(TestDynamicConfigHandler)
 	cmSource.Watch(dynHandler)


### PR DESCRIPTION
if we add filename3 before filename1 and filename2, then the test failed.
```
cmSource.AddFile(filename3, 2, nil)
cmSource.AddFile(filename1, 0, nil)
cmSource.AddFile(filename2, 1, nil)
```
This is because we did not save the corresponding filepath when encountering a higher priority value.